### PR TITLE
Set .s3cfg owner to s3cmd_user

### DIFF
--- a/tasks/s3cmd.yml
+++ b/tasks/s3cmd.yml
@@ -5,4 +5,5 @@
   template: >
     src=../templates/s3cfg.j2
     dest=~{{ s3cmd_user }}/.s3cfg
+    owner={{ s3cmd_user }}
     mode=600


### PR DESCRIPTION
otherwise you get permission denied if the ansible user differs from the specified user
